### PR TITLE
chore: añadir .kiro/ a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 GNU.Linux/packages.microsoft.gpg
 .claude/
 GEMINI.md
+.kiro/


### PR DESCRIPTION
Kiro CLI lee contexto vía .kiro/steering/context.md (symlink gestionado por myClaudeContext), igual que GEMINI.md. Se excluye del repo.